### PR TITLE
Fix old C++ app launch when compiled with new C++

### DIFF
--- a/Makefile.rg-350
+++ b/Makefile.rg-350
@@ -31,7 +31,8 @@ CFLAGS = \
     -mplt \
     -msym32 \
 	-funroll-loops \
-	-fomit-frame-pointer
+	-fomit-frame-pointer \
+	-D_GLIBCXX_USE_CXX11_ABI=0
 
 CXXFLAGS = $(CFLAGS)
 LDFLAGS = $(SDL_LIBS) -lfreetype -lSDL_image -lSDL_ttf -lSDL_gfx -lSDL_mixer -lSDL -lpthread -lopk -lpng -lasound


### PR DESCRIPTION
GCC 5.1+ uses a different ABI from earlier releases.

esoteric uses `execvp()` to launch apps.
The C `exec*` functions do not reload shared libs in memory but only replace main module and load new shared libs. If launching an app compiled with GCC 4.9, there would be an ABI conflict.

This change enables the GCC C++ Dual ABI feature to let gmenu2x launch both old and new ABI apps.
See https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html

This is in preparation for the official RG-350 buildroot update to GCC 5.1+
See https://github.com/tonyjih/RG350_buildroot/pull/53 which adds a similar change to gmenu2x